### PR TITLE
If using Darwin, override libressl with openssl 1.1 from homebrew.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -36,6 +36,11 @@ for DIR in $PATHDIR; do
   done
 done
 
+## override libressl in os x
+openssl_version=1.1.1g
+[[ $(uname) == 'Darwin' ]] && 
+  PATH=/usr/local/Cellar/openssl\@1.1/${openssl_version}/bin:$PATH
+
 ## PS1
 ## bash built-in colors  
 txtblk='\[\e[0;30m\]' ## black regular

--- a/.emacs
+++ b/.emacs
@@ -7,11 +7,25 @@
 ;; just comment it out by adding a semicolon to the start of the line.
 ;; You may delete these explanatory comments.
 (package-initialize)
-
 (setq load-path (cons "~/.emacs.d/site-lisp" load-path))
 
 ;; get rid of slashes for cut-n-paste
 (set-display-table-slot standard-display-table 'wrap ?\ )
+
+;; discard newlines when cutting and pasting region
+(defun my-copy-simple (beg end)
+  "Save the current region to the kill ring after stripping extra whitespace and new lines"
+  (interactive "r")
+  (copy-region-as-kill beg end)
+  (with-temp-buffer 
+    (yank)
+    (goto-char 0)
+    (while (looking-at "[ \t\n]")
+      (delete-char 1))
+    (compact-uncompact-block)
+    (mark-whole-buffer)
+    (kill-region (point-min) (point-max))))
+
 
 ;; disable transient-mark-mode
 (transient-mark-mode 0)
@@ -42,6 +56,8 @@
 (require 'yaml-mode nil 'missing-okay)
 (add-to-list 'auto-mode-alist '("\\.yml\\'" . yaml-mode))
 
+
+
 ;; elpa
 (require 'package)
 (let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))
@@ -57,11 +73,17 @@
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
  '(package-selected-packages
-   (quote
-    (dockerfile-mode go-mode mmm-mode rinari web-mode enh-ruby-mode systemd markdown-mode chef-mode json-mode yaml-mode docker-compose-mode terraform-mode))))
+	 (quote
+		(rust-mode jinja2-mode dockerfile-mode go-mode mmm-mode rinari web-mode enh-ruby-mode systemd markdown-mode chef-mode json-mode yaml-mode docker-compose-mode terraform-mode))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
  )
+
+(when (>= emacs-major-version 24)
+  (require 'package)
+  (package-initialize)
+  (add-to-list 'package-archives '("melpa" . "http://melpa.milkbox.net/packages/") t)
+  )


### PR DESCRIPTION
- If using `Darwin`, override libressl with openssl 1.1 from homebrew